### PR TITLE
Parse timestamped zsh history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,158 @@
+
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### Python Patch ###
+.venv/
+
+# End of https://www.gitignore.io/api/python
+
+# Created by https://www.gitignore.io/api/macos
+# Edit at https://www.gitignore.io/?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# End of https://www.gitignore.io/api/macos

--- a/command_line_lint.py
+++ b/command_line_lint.py
@@ -23,6 +23,7 @@ import os
 import stat
 import sys
 import difflib
+import io
 from collections import Counter, defaultdict
 from subprocess import check_output, CalledProcessError
 
@@ -421,7 +422,7 @@ def _history_file():
 
 
 def _commands():
-    with open(_history_file(), errors="replace") as stream:
+    with io.open(_history_file(), errors='replace') as stream:
         return [
             _normalize(cmd) for cmd in stream.readlines() if _normalize(cmd)
         ]

--- a/command_line_lint.py
+++ b/command_line_lint.py
@@ -405,8 +405,8 @@ def _history_file():
     if len(sys.argv) > 1:
         history_file = sys.argv[1]
     elif os.environ.get('HISTFILE'):
-        # typical zsh:
         history_file = os.path.join(home, os.environ.get('HISTFILE'))
+    # typical zsh:
     elif _shell() == 'zsh':
         history_file = os.path.join(home, '.zsh_history')
     elif _shell() == 'bash':
@@ -428,14 +428,14 @@ def _commands():
 
 
 def _normalize(cmd):
-    """Squash extra whitespace"""
+    # Squash extra whitespace
     cmd = ' '.join(cmd.split())
 
-    """Remove timestamps from commands in zsh's timestamped history"""
+    # Remove timestamps from commands in zsh's timestamped history
     if _shell() == 'zsh':
-        cmd = re.sub('^: \d+:\d+;', '', cmd, count=1)
+        cmd = re.sub(r'^: \d+:\d+;', '', cmd, count=1)
 
-    """Drop command if it was a comment."""
+    # Drop command if it was a comment.
     return '' if cmd.startswith('#') else cmd
 
 

--- a/command_line_lint.py
+++ b/command_line_lint.py
@@ -407,6 +407,8 @@ def _history_file():
     elif os.environ.get('HISTFILE'):
         # typical zsh:
         history_file = os.path.join(home, os.environ.get('HISTFILE'))
+    elif _shell() == 'zsh':
+        history_file = os.path.join(home, '.zsh_history')
     elif _shell() == 'bash':
         history_file = os.path.join(home, '.bash_history')
     else:

--- a/command_line_lint.py
+++ b/command_line_lint.py
@@ -428,8 +428,14 @@ def _commands():
 
 
 def _normalize(cmd):
-    """Squash extra whitespace; drop command if it was a comment."""
+    """Squash extra whitespace"""
     cmd = ' '.join(cmd.split())
+
+    """Remove timestamps from commands in zsh's timestamped history"""
+    if _shell() == 'zsh':
+        cmd = re.sub('^: \d+:\d+;', '', cmd, count=1)
+
+    """Drop command if it was a comment."""
     return '' if cmd.startswith('#') else cmd
 
 

--- a/command_line_lint.py
+++ b/command_line_lint.py
@@ -421,7 +421,7 @@ def _history_file():
 
 
 def _commands():
-    with open(_history_file()) as stream:
+    with open(_history_file(), errors="replace") as stream:
         return [
             _normalize(cmd) for cmd in stream.readlines() if _normalize(cmd)
         ]


### PR DESCRIPTION
Addresses issue #1 and avoids crashes due to unicode parsing errors.
Also, since the zsh setup wizard sets the default history file to `$HOME/.zsh_history`, the script uses this file if using zsh (unless HISTFILE is set).