### PR TITLE
Make script directly executable

### DIFF
--- a/command_line_lint.py
+++ b/command_line_lint.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Command-Line Lint --- lint your command-line history.
 
 Author: Chris Rayner (dchrisrayner@gmail.com)


### PR DESCRIPTION
Should the script be directly executable?

I added a hashbang to run with Python, and changed the permissions to make `command_line_lint.py` executable by anyone.

The motivation for this was so I could clone the script directly into my user-local executables folder, and have it automatically loaded onto the path. I can then call it directly whenever I want to check my history, rather than going through Python.